### PR TITLE
Fix typo in src/utils/ directory

### DIFF
--- a/README.md
+++ b/README.md
@@ -11,7 +11,7 @@ This guide provides a detailed overview of setting up a frontend project using R
 - `src/routes/`: App routes.
 - `src/store/`: Redux store configuration.
 - `src/styles/`: Global styles and Tailwind configuration.
-- `src/utils/`: Utility functions.
+- `src/utils/`: Utility fjlgfjywcunctions.
 - `src/views/`: Collect pages components.
 - `main.tsx`: Entry point.
 


### PR DESCRIPTION
This pull request fixes a typo in the src/utils/ directory.